### PR TITLE
Require Ruby version: >= 1.9.3; Fix dependency: active_support -> activesupport.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Installation process takes a step, type a following command:
 Need to install:
 
 * [Ruby](https://www.ruby-lang.org/)
-    * `ruby --version` >= 1.9.2
+    * `ruby --version` >= 1.9.3
 * [Git](http://git-scm.com/)
     * `git --version` >= 1.7
 

--- a/git-contest.gemspec
+++ b/git-contest.gemspec
@@ -20,11 +20,13 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = '>= 1.9.3' 
+
   spec.add_dependency "mechanize"
   spec.add_dependency "nokogiri"
   spec.add_dependency "trollop"
   spec.add_dependency "highline"
-  spec.add_dependency "active_support"
+  spec.add_dependency "activesupport"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Require Ruby version: >= 1.9.3
Fix dependency: active_support -> activesupport.
